### PR TITLE
Disable springdoc api-docs in prod

### DIFF
--- a/apps/api/src/main/resources/application-prod.yml
+++ b/apps/api/src/main/resources/application-prod.yml
@@ -1,3 +1,3 @@
 springdoc:
   api-docs:
-    enabled: ${SPRINGDOC_API_DOCS_ENABLED:false}
+    enabled: ${SPRING_DOC_API_DOCS_ENABLED:false}


### PR DESCRIPTION
## Summary\n- disable SpringDoc /v3/api-docs in production via application-prod.yml\n- allow override via SPRING_DOC_API_DOCS_ENABLED (default false)\n\n## Testing\n- not run (config-only change)