### PR TITLE
Add example configs and secrets guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+FIREBASE_CONFIG_PATH=./firebase_config.json
+FIREBASE_API_KEY=YOUR_FIREBASE_API_KEY
+VERSION=local
+SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/feedback_db
+SPRING_DATASOURCE_USERNAME=postgres
+SPRING_DATASOURCE_PASSWORD=postgres
+SPRING_DOC_API_DOCS_ENABLED=true
+LOG_PATH=./logs
+IMAP_HOST=imap.example.com
+IMAP_PASSWORD=your-imap-password
+IMAP_USERNAME=feedback@example.com
+IMAP_FOLDER=INBOX
+IMAP_PORT=993
+SHOW_EXPOSED_SQL=true
+API_PORT=8080
+JWT_JWK_SET_URL=https://www.googleapis.com/oauth2/v3/certs
+JWT_ISSUER_URI=https://securetoken.google.com/your-project-id

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ Kotlin + Spring Boot services powering the LetsGrow feedback platform. Provides 
 - JDK 21 (toolchain); Kotlin 1.9; Gradle wrapper included.
 - Docker (optional) for running Postgres locally.
 - Environment: `SPRING_DATASOURCE_URL/USERNAME/PASSWORD` for Postgres, `FIREBASE_API_KEY`, `FIREBASE_CONFIG_PATH`, optional `SHOW_EXPOSED_SQL=true`. Email listener needs `IMAP_HOST`, `IMAP_PORT`, `IMAP_USERNAME`, `IMAP_PASSWORD`, and `IMAP_FOLDER`. Base version is set in `gradle.properties` (CI appends build metadata).
+- Secrets: copy `.env.example` and `firebase_config.json.example` to `.env` and `firebase_config.json`, then fill in real values. Keep those files out of git.
 
 ## Quick Start (API)
 ```bash
 cp firebase_config.json.example firebase_config.json   # if provided
+cp .env.example .env                                   # add env vars for local runs
 ./gradlew :apps:api:bootRun                            # starts on :8080, H2 in-memory by default
 # or point to Postgres
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/feedback \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,12 @@
    ```bash
    docker run --name feedback-db -e POSTGRES_DB=feedback -e POSTGRES_USER=feedback -e POSTGRES_PASSWORD=secret -p 5432:5432 -d postgres:16
    ```
-3. Set environment variables (H2 defaults work if you skip Postgres):
+3. Copy example configs and fill in real values:
+   ```bash
+   cp .env.example .env
+   cp firebase_config.json.example firebase_config.json
+   ```
+4. Set environment variables (H2 defaults work if you skip Postgres):
    ```bash
    export SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/feedback
    export SPRING_DATASOURCE_USERNAME=feedback

--- a/firebase_config.json.example
+++ b/firebase_config.json.example
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  "private_key_id": "REPLACE_ME",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nREPLACE_ME\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk@example.iam.gserviceaccount.com",
+  "client_id": "REPLACE_ME",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk%40example.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
+}


### PR DESCRIPTION
## Summary\n- add example .env and firebase service account config files\n- document copying examples and keeping secrets out of git\n\n## Testing\n- not run (docs/config-only change)