### PR TITLE
Move admin Firebase usage into firebase module

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
 
     implementation(libs.bundles.jackson)
     implementation(libs.springdoc.openapi.starter.webmvc)
-    implementation(libs.firebase)
-
     runtimeOnly(libs.liquibase.core)
     runtimeOnly(libs.postgres)
 

--- a/apps/api/src/main/kotlin/dk/example/feedback/service/AdminService.kt
+++ b/apps/api/src/main/kotlin/dk/example/feedback/service/AdminService.kt
@@ -1,11 +1,10 @@
 package dk.example.feedback.service
 
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.UserRecord
 import dk.example.feedback.config.FeedbackConfig
 import dk.example.feedback.controller.AdminController.MockTokenDto
-
 import dk.example.feedback.controller.AdminController.SignInFirebaseResponseDto
+import dk.example.feedback.firebase.FirebaseAdminService
+import dk.example.feedback.firebase.FirebaseService
 import dk.example.feedback.model.enumerations.Role
 import dk.example.feedback.persistence.repo.AccountRepo
 import org.slf4j.LoggerFactory
@@ -18,6 +17,8 @@ import org.springframework.web.client.postForEntity
 class AdminService(
     val feedbackConfig: FeedbackConfig,
     val accountRepo: AccountRepo,
+    val firebaseAdminService: FirebaseAdminService,
+    val firebaseService: FirebaseService,
 ) {
 
     private val logger = LoggerFactory.getLogger(AdminService::class.java)
@@ -31,24 +32,18 @@ class AdminService(
             accountId = uid,
         )
 
-        val createUserRequest = UserRecord.CreateRequest()
-            .setUid(uid)
-            .setEmail("mock@mock.dk")
-            .setDisplayName("Mocked displayname")
-
+        firebaseAdminService.createUserIfMissing(
+            uid = uid,
+            email = "mock@mock.dk",
+            displayName = "Mocked displayname"
+        )
         try {
-            logger.debug("Firebase: Creating user")
-            FirebaseAuth.getInstance().createUser(createUserRequest)
-        } catch (e: Exception) {
-            logger.debug("Firebase: User already exists so will sign in")
-        }
-        try {
-            FirebaseAuth.getInstance().setCustomUserClaimsAsync(uid, mapOf("role" to role.toString()))
+            firebaseService.setRole(userId = uid, requestedRole = role)
         } catch (e: Exception) {
             logger.debug("Firebase: Failed to set custom claims for role with value {}", role)
         }
-        val token = FirebaseAuth.getInstance().createCustomTokenAsync(uid)
-        return signInWithCustomToken(token.get())
+        val token = firebaseAdminService.createCustomToken(uid = uid)
+        return signInWithCustomToken(token)
     }
 
     fun signInWithCustomToken(token: String): MockTokenDto {

--- a/apps/api/src/test/kotlin/dk/example/feedback/utils/FirebaseMockEngine.kt
+++ b/apps/api/src/test/kotlin/dk/example/feedback/utils/FirebaseMockEngine.kt
@@ -1,11 +1,12 @@
 package dk.example.feedback.utils
 
 import dk.example.feedback.firebase.FeedbackReceivedNotification
+import dk.example.feedback.firebase.FirebaseAdminService
 import dk.example.feedback.firebase.FirebaseService
 import dk.example.feedback.firebase.FirebaseUser
 import dk.example.feedback.model.enumerations.Role
 
-class FirebaseMockEngine(userId: String) : FirebaseService {
+class FirebaseMockEngine(userId: String) : FirebaseService, FirebaseAdminService {
 
 
     private var user: FirebaseUser? = FirebaseUser(
@@ -45,6 +46,12 @@ class FirebaseMockEngine(userId: String) : FirebaseService {
         println("🚀 Before setting role: Current role = $role, New role = $requestedRole")
         role = requestedRole
         println("✅ After setting role: Current role = $role")
+    }
+
+    override fun createUserIfMissing(uid: String, email: String, displayName: String) {}
+
+    override fun createCustomToken(uid: String): String {
+        return "mock-custom-token-$uid"
     }
 
 //    suspend fun getToken(): SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor {

--- a/apps/api/src/test/kotlin/dk/example/feedback/utils/TestConfig.kt
+++ b/apps/api/src/test/kotlin/dk/example/feedback/utils/TestConfig.kt
@@ -1,5 +1,6 @@
 package dk.example.feedback.utils
 
+import dk.example.feedback.firebase.FirebaseAdminService
 import dk.example.feedback.firebase.FirebaseService
 import java.time.Instant
 import org.springframework.boot.test.context.TestConfiguration
@@ -14,6 +15,11 @@ class TestConfig {
         return FirebaseMockEngine(
             userId = "mock_id_unit_tests"
         )
+    }
+
+    @Bean
+    fun firebaseAdminService(firebaseService: FirebaseService): FirebaseAdminService {
+        return firebaseService as FirebaseAdminService
     }
 
     @Bean

--- a/lib/firebase/src/main/kotlin/dk/example/feedback/firebase/FirebaseAdminService.kt
+++ b/lib/firebase/src/main/kotlin/dk/example/feedback/firebase/FirebaseAdminService.kt
@@ -1,0 +1,6 @@
+package dk.example.feedback.firebase
+
+interface FirebaseAdminService {
+    fun createUserIfMissing(uid: String, email: String, displayName: String)
+    fun createCustomToken(uid: String): String
+}

--- a/lib/firebase/src/main/kotlin/dk/example/feedback/firebase/FirebaseServiceImpl.kt
+++ b/lib/firebase/src/main/kotlin/dk/example/feedback/firebase/FirebaseServiceImpl.kt
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class FirebaseServiceImpl : FirebaseService {
+class FirebaseServiceImpl : FirebaseService, FirebaseAdminService {
 
     private val logger = LoggerFactory.getLogger(FirebaseServiceImpl::class.java)
 
@@ -99,5 +99,23 @@ class FirebaseServiceImpl : FirebaseService {
             logger.error("Failed to set role for user $userId", e)
             throw RuntimeException("Failed to set role", e)
         }
+    }
+
+    override fun createUserIfMissing(uid: String, email: String, displayName: String) {
+        val createUserRequest = UserRecord.CreateRequest()
+            .setUid(uid)
+            .setEmail(email)
+            .setDisplayName(displayName)
+
+        try {
+            logger.debug("Firebase: Creating user")
+            FirebaseAuth.getInstance().createUser(createUserRequest)
+        } catch (e: Exception) {
+            logger.debug("Firebase: User already exists so will sign in")
+        }
+    }
+
+    override fun createCustomToken(uid: String): String {
+        return FirebaseAuth.getInstance().createCustomTokenAsync(uid).get()
     }
 }


### PR DESCRIPTION
## Summary
- remove Firebase SDK dependency from the API module
- add a Firebase admin interface in lib/firebase and route admin token creation through it
- update API service/test wiring for the new interface

## Testing
- not run (not requested)