### PR TITLE
Fix local Docker Compose Firebase config mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,9 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/feedback
       SPRING_DATASOURCE_USERNAME: feedback
       SPRING_DATASOURCE_PASSWORD: feedback
-      FIREBASE_CONFIG_PATH: firebase_config.json
+      FIREBASE_CONFIG_PATH: /app/firebase_config.json
     volumes:
-      - ./firebase_config.json:/app/secrets/firebase_config.json:ro
+      - ./firebase_config.json:/app/firebase_config.json:ro
     depends_on:
       db:
         condition: service_healthy
@@ -59,9 +59,9 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/feedback
       SPRING_DATASOURCE_USERNAME: feedback
       SPRING_DATASOURCE_PASSWORD: feedback
-      FIREBASE_CONFIG_PATH: /app/secrets/firebase_config.json
+      FIREBASE_CONFIG_PATH: /app/firebase_config.json
     volumes:
-      - ./firebase_config.json:/app/secrets/firebase_config.json:ro
+      - ./firebase_config.json:/app/firebase_config.json:ro
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- fix the local `docker compose` Firebase config bind mount to target `/app/firebase_config.json`, a path that exists in the backend containers
- align `FIREBASE_CONFIG_PATH` for both `api` and `scheduler` to the same in-container file path
- keep the change limited to root-level local orchestration in `docker-compose.yml`

## Validation
- `docker compose config`
- `docker compose up --build -d`
- `docker compose ps`
- `docker compose logs --tail=25 api scheduler web db`
- `docker compose down`

Closes #31.
