### PR TITLE
Move compose deploy to versioned images and Jib release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,10 @@ jobs:
       - name: Compute versions
         run: |
           CALVER_DATE="$(date -u +'%Y.%m.%d')"
-          RELEASE_LABEL="${CALVER_DATE}.${BUILD_NUMBER}"
-          RELEASE_TAG="rel-${RELEASE_LABEL}"
-          FULL_SHA="${GITHUB_SHA}"
-          SHORT_SHA=${GITHUB_SHA:0:7}
-          # Use SHA as immutable deploy identity; keep CalVer as human release label.
-          DOCKER_TAG_SHA="sha-${FULL_SHA}"
-          DOCKER_TAG_RELEASE="rel-${RELEASE_LABEL}"
-          echo "RELEASE_LABEL=$RELEASE_LABEL" >> $GITHUB_ENV
+          VERSION="${CALVER_DATE}.${BUILD_NUMBER}"
+          RELEASE_TAG="rel-${VERSION}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
-          echo "FULL_SHA=$FULL_SHA" >> $GITHUB_ENV
-          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
-          echo "DOCKER_TAG_SHA=$DOCKER_TAG_SHA" >> $GITHUB_ENV
-          echo "DOCKER_TAG_RELEASE=$DOCKER_TAG_RELEASE" >> $GITHUB_ENV
 
       - name: Set up JDK environment
         uses: actions/setup-java@v4
@@ -44,17 +35,8 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
-      - name: Install Render CLI
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/render-oss/cli/refs/heads/main/bin/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Validate Render Blueprint
-        run: render blueprints validate render.yaml
-
       - name: Generate OpenAPI spec
         env:
-          VERSION: ${{ env.RELEASE_LABEL }}
           SPRING_PROFILES_ACTIVE: openapi
         run: |
           ./gradlew :api:generateOpenApiDocs --no-configuration-cache -Pversion=${VERSION}
@@ -66,25 +48,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and publish API image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: backend/apps/api/Dockerfile
-          push: true
-          tags: |
-            nicolaidam/feedback-api:${{ env.DOCKER_TAG_SHA }}
-            nicolaidam/feedback-api:${{ env.DOCKER_TAG_RELEASE }}
-
-      - name: Build and publish scheduler image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: backend/apps/scheduler/Dockerfile
-          push: true
-          tags: |
-            nicolaidam/feedback-scheduler:${{ env.DOCKER_TAG_SHA }}
-            nicolaidam/feedback-scheduler:${{ env.DOCKER_TAG_RELEASE }}
+      - name: Build and publish backend images with Jib
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          ./gradlew :api:jib :scheduler:jib --no-configuration-cache -Pversion=${VERSION}
+        working-directory: backend
 
       - name: Build and publish frontend image
         uses: docker/build-push-action@v6
@@ -102,14 +72,13 @@ jobs:
             NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL=${{ vars.NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL }}
           push: true
           tags: |
-            nicolaidam/feedback-web:${{ env.DOCKER_TAG_SHA }}
-            nicolaidam/feedback-web:${{ env.DOCKER_TAG_RELEASE }}
+            nicolaidam/feedback-web:${{ env.VERSION }}
 
       - name: Create and Push Git Tag
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ env.RELEASE_TAG }}" -m "Release ${{ env.RELEASE_LABEL }} (${GITHUB_SHA})"
+          git tag -a "${{ env.RELEASE_TAG }}" -m "Release ${{ env.VERSION }} (${GITHUB_SHA})"
           git push origin "${{ env.RELEASE_TAG }}"
 
       - name: Create GitHub Release
@@ -119,4 +88,27 @@ jobs:
           gh release create "${{ env.RELEASE_TAG }}" \
             backend/apps/api/build/openapi.yaml \
             --generate-notes \
-            --title "Release ${{ env.RELEASE_LABEL }}"
+            --title "Release ${{ env.VERSION }}"
+
+      - name: Verify Coolify webhook configuration
+        env:
+          COOLIFY_DEPLOY_WEBHOOK_URL: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          if [ -z "$COOLIFY_DEPLOY_WEBHOOK_URL" ]; then
+            echo "Missing required secret: COOLIFY_DEPLOY_WEBHOOK_URL" >&2
+            exit 1
+          fi
+          if [ -z "$COOLIFY_TOKEN" ]; then
+            echo "Missing required secret: COOLIFY_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Trigger Coolify deployment
+        env:
+          COOLIFY_DEPLOY_WEBHOOK_URL: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          curl --silent --show-error --fail --request GET \
+            "$COOLIFY_DEPLOY_WEBHOOK_URL" \
+            --header "Authorization: Bearer $COOLIFY_TOKEN"

--- a/backend/apps/api/build.gradle.kts
+++ b/backend/apps/api/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.openapi)
+    alias(libs.plugins.jib)
     kotlin("plugin.spring") version libs.versions.kotlin
     alias(libs.plugins.springboot)
     alias(libs.plugins.spring.dependencies)
@@ -36,6 +37,10 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.withType<com.google.cloud.tools.jib.gradle.BuildDockerTask>().configureEach {
+    notCompatibleWithConfigurationCache("Jib Docker task is not configuration-cache compatible in this setup.")
+}
+
 // Generate build metadata so Spring can read the build version at runtime.
 springBoot {
     buildInfo()
@@ -45,4 +50,17 @@ openApi {
     apiDocsUrl.set("http://localhost:8080/v3/api-docs")
     outputFileName.set("openapi.yaml")
     waitTimeInSeconds.set(60)
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:21-jre"
+    }
+    to {
+        image = "nicolaidam/feedback-api:${project.version}"
+        auth {
+            username = System.getenv("DOCKER_USERNAME")
+            password = System.getenv("DOCKER_PASSWORD")
+        }
+    }
 }

--- a/backend/apps/api/src/main/resources/application-openapi.yml
+++ b/backend/apps/api/src/main/resources/application-openapi.yml
@@ -17,9 +17,9 @@ spring:
       initialization-fail-timeout: 0
 springdoc:
   api-docs:
-    enabled: true
+    enabled: ${SPRING_DOC_API_DOCS_ENABLED:true}
   swagger-ui:
-    enabled: false
+    enabled: ${SPRING_DOC_SWAGGER_UI_ENABLED:true}
 server:
   port: 8080
 management:

--- a/backend/apps/scheduler/build.gradle.kts
+++ b/backend/apps/scheduler/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.jib)
     kotlin("plugin.spring") version libs.versions.kotlin
     alias(libs.plugins.springboot)
     alias(libs.plugins.spring.dependencies)
@@ -27,7 +28,7 @@ dependencies {
     testImplementation(libs.springboot.testcontainers)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.kotlin.test.junit5)
-    testRuntimeOnly(libs.h2)
+    runtimeOnly(libs.h2)
     testRuntimeOnly(libs.junit.platform.launcher)
 }
 
@@ -35,7 +36,24 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.withType<com.google.cloud.tools.jib.gradle.BuildDockerTask>().configureEach {
+    notCompatibleWithConfigurationCache("Jib Docker task is not configuration-cache compatible in this setup.")
+}
+
 // Generate build metadata so Spring can read the build version at runtime.
 springBoot {
     buildInfo()
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:21-jre"
+    }
+    to {
+        image = "nicolaidam/feedback-scheduler:${project.version}"
+        auth {
+            username = System.getenv("DOCKER_USERNAME")
+            password = System.getenv("DOCKER_PASSWORD")
+        }
+    }
 }

--- a/backend/apps/scheduler/src/main/resources/application.yml
+++ b/backend/apps/scheduler/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 server:
-  port: 8080
+  port: ${PORT:8080}
   shutdown: graceful
   max-http-request-header-size: 16KB
 management:
   server:
-    port: 8091
+    port: ${MANAGEMENT_SERVER_PORT:8091}
   endpoints:
     web:
       exposure:

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ openapi = "1.9.0"
 firebase = "9.7.0"
 ical4j = "4.2.2"
 h2 = "2.3.232"
+jib = "3.5.3"
 
 [libraries]
 
@@ -58,6 +59,7 @@ springdoc-openapi-starter-webmvc = { module = "org.springdoc:springdoc-openapi-s
 springboot = { id = "org.springframework.boot", version.ref = "springboot" }
 spring-dependencies = { id = "io.spring.dependency-management", version.ref = "springDependencyPlugin" }
 openapi = { id = "org.springdoc.openapi-gradle-plugin", version.ref = "openapi" }
+jib = { id = "com.google.cloud.tools.jib", version.ref = "jib" }
 
 [bundles]
 jackson = ["jackson-module-kotlin", "jackson-datatype-jsr310"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,69 @@
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB:-feedback}"
+      POSTGRES_USER: "${POSTGRES_USER:-feedback}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-feedback}"
+    ports:
+      - "${DB_HOST_PORT:-5432}:5432"
+    volumes:
+      - feedback-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-feedback} -d ${POSTGRES_DB:-feedback}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  api:
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: "openapi"
+      SPRING_MAIN_LAZY_INITIALIZATION: "false"
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/${POSTGRES_DB:-feedback}"
+      SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-feedback}"
+      SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:-feedback}"
+      JWT_JWK_SET_URL: "http://localhost:65535/jwks"
+      JWT_ISSUER_URI: ""
+      FIREBASE_API_KEY: "${FIREBASE_API_KEY:-}"
+      FIREBASE_CONFIG_PATH: "${FIREBASE_CONFIG_PATH:-}"
+    ports:
+      - "${API_HOST_PORT:-8080}:8080"
+      - "${API_MANAGEMENT_HOST_PORT:-8090}:8090"
+
+  scheduler:
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/${POSTGRES_DB:-feedback}"
+      SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-feedback}"
+      SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:-feedback}"
+      FIREBASE_API_KEY: "${FIREBASE_API_KEY:-}"
+      FIREBASE_CONFIG_PATH: "${FIREBASE_CONFIG_PATH:-}"
+    ports:
+      - "${SCHEDULER_MANAGEMENT_HOST_PORT:-8091}:8091"
+
+  web:
+    image: "feedback-web:local"
+    pull_policy: never
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL: ${NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL:-}
+        NEXT_PUBLIC_FIREBASE_API_KEY: ${NEXT_PUBLIC_FIREBASE_API_KEY:-}
+        NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:-}
+        NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${NEXT_PUBLIC_FIREBASE_PROJECT_ID:-}
+        NEXT_PUBLIC_FIREBASE_APP_ID: ${NEXT_PUBLIC_FIREBASE_APP_ID:-}
+        NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:-}
+        NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:-}
+        NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID:-}
+    ports:
+      - "${WEB_HOST_PORT:-3000}:3000"
+
+volumes:
+  feedback-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,86 +1,55 @@
 name: feedback
 
 services:
-  db:
-    image: postgres:17-alpine
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: feedback
-      POSTGRES_USER: feedback
-      POSTGRES_PASSWORD: feedback
-    ports:
-      - "${DB_HOST_PORT:-5432}:5432"
-    volumes:
-      - feedback-postgres:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U feedback -d feedback"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-
   api:
-    build:
-      context: .
-      dockerfile: backend/apps/api/Dockerfile
+    image: "nicolaidam/feedback-api:${VERSION}"
     restart: unless-stopped
-    env_file:
-      - .env
     environment:
       PORT: "8080"
       MANAGEMENT_SERVER_PORT: "8090"
-      SPRING_PROFILES_ACTIVE: prod
+      SPRING_PROFILES_ACTIVE: "${API_SPRING_PROFILES_ACTIVE:-prod}"
       SPRING_DOC_API_DOCS_ENABLED: "true"
       SPRING_DOC_SWAGGER_UI_ENABLED: "true"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/feedback
-      SPRING_DATASOURCE_USERNAME: feedback
-      SPRING_DATASOURCE_PASSWORD: feedback
-      FIREBASE_CONFIG_PATH: /app/firebase_config.json
-    volumes:
-      - ./firebase_config.json:/app/firebase_config.json:ro
-    depends_on:
-      db:
-        condition: service_healthy
-    ports:
-      - "${API_HOST_PORT:-18080}:8080"
-      - "${API_MANAGEMENT_HOST_PORT:-18090}:8090"
+      SPRING_DATASOURCE_URL: "${API_SPRING_DATASOURCE_URL:-}"
+      SPRING_DATASOURCE_USERNAME: "${API_SPRING_DATASOURCE_USERNAME:-}"
+      SPRING_DATASOURCE_PASSWORD: "${API_SPRING_DATASOURCE_PASSWORD:-}"
+      JWT_JWK_SET_URL: "${API_JWT_JWK_SET_URL:-}"
+      JWT_ISSUER_URI: "${API_JWT_ISSUER_URI:-}"
+      FIREBASE_API_KEY: "${API_FIREBASE_API_KEY:-}"
+      FIREBASE_CONFIG_PATH: "${API_FIREBASE_CONFIG_PATH:-}"
+      JAVA_OPTS: "${API_JAVA_OPTS:--Xmx512m}"
+      JAVA_TOOL_OPTIONS: "${API_JAVA_OPTS:--Xmx512m}"
+    expose:
+      - "8080"
+      - "8090"
 
   scheduler:
-    build:
-      context: .
-      dockerfile: backend/apps/scheduler/Dockerfile
+    image: "nicolaidam/feedback-scheduler:${VERSION}"
     restart: unless-stopped
-    env_file:
-      - .env
     environment:
       PORT: "8080"
       MANAGEMENT_SERVER_PORT: "8091"
-      SPRING_PROFILES_ACTIVE: prod
-      SPRING_LIQUIBASE_ENABLED: "false"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/feedback
-      SPRING_DATASOURCE_USERNAME: feedback
-      SPRING_DATASOURCE_PASSWORD: feedback
-      FIREBASE_CONFIG_PATH: /app/firebase_config.json
-    volumes:
-      - ./firebase_config.json:/app/firebase_config.json:ro
-    depends_on:
-      db:
-        condition: service_healthy
-    ports:
-      - "${SCHEDULER_MANAGEMENT_HOST_PORT:-18091}:8091"
+      SPRING_PROFILES_ACTIVE: "${SCHEDULER_SPRING_PROFILES_ACTIVE:-prod}"
+      SPRING_LIQUIBASE_ENABLED: "${SCHEDULER_SPRING_LIQUIBASE_ENABLED:-true}"
+      SPRING_DATASOURCE_URL: "${SCHEDULER_SPRING_DATASOURCE_URL:-}"
+      SPRING_DATASOURCE_USERNAME: "${SCHEDULER_SPRING_DATASOURCE_USERNAME:-}"
+      SPRING_DATASOURCE_PASSWORD: "${SCHEDULER_SPRING_DATASOURCE_PASSWORD:-}"
+      FIREBASE_API_KEY: "${SCHEDULER_FIREBASE_API_KEY:-}"
+      FIREBASE_CONFIG_PATH: "${SCHEDULER_FIREBASE_CONFIG_PATH:-}"
+      ZOHO_ACCOUNT_ID: "${ZOHO_ACCOUNT_ID:-}"
+      ZOHO_FOLDER_ID: "${ZOHO_FOLDER_ID:-}"
+      ZOHO_MAILBOX_ADDRESS: "${ZOHO_MAILBOX_ADDRESS:-}"
+      ZOHO_OAUTH_REFRESH_TOKEN: "${ZOHO_OAUTH_REFRESH_TOKEN:-}"
+      ZOHO_CLIENT_ID: "${ZOHO_CLIENT_ID:-}"
+      ZOHO_CLIENT_SECRET: "${ZOHO_CLIENT_SECRET:-}"
+      JAVA_OPTS: "${SCHEDULER_JAVA_OPTS:--Xmx512m}"
+      JAVA_TOOL_OPTIONS: "${SCHEDULER_JAVA_OPTS:--Xmx512m}"
+    expose:
+      - "8080"
+      - "8091"
 
   web:
-    build:
-      context: ./web
-      dockerfile: Dockerfile
-      args:
-        NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL: ${NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL:-}
-        NEXT_PUBLIC_FIREBASE_API_KEY: ${NEXT_PUBLIC_FIREBASE_API_KEY:-}
-        NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:-}
-        NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${NEXT_PUBLIC_FIREBASE_PROJECT_ID:-}
-        NEXT_PUBLIC_FIREBASE_APP_ID: ${NEXT_PUBLIC_FIREBASE_APP_ID:-}
-        NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:-}
-        NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:-}
-        NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID:-}
+    image: "nicolaidam/feedback-web:${VERSION}"
     restart: unless-stopped
     environment:
       NODE_ENV: production
@@ -96,8 +65,5 @@ services:
       NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID:-}
     depends_on:
       - api
-    ports:
-      - "${WEB_HOST_PORT:-3000}:3000"
-
-volumes:
-  feedback-postgres:
+    expose:
+      - "3000"


### PR DESCRIPTION
## Summary
- switch root `docker-compose.yml` services (`api`, `scheduler`, `web`) to versioned prebuilt images using `VERSION`
- add `docker-compose.override.yml` for local db/ports/build overrides while inheriting service definitions from default compose
- publish backend images with Jib in release workflow and trigger Coolify deploy webhook
- keep scheduler port runtime-configurable via `PORT` / `MANAGEMENT_SERVER_PORT`
- make openapi profile swagger flags env-driven (`SPRING_DOC_*`)

## Validation
- `docker compose config -q`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml config -q`
- local smoke check: `docker compose up -d --remove-orphans`, API docs + scheduler health reachable, then `docker compose down`

## Coolify follow-up
- set `VERSION` on the app to the release tag published by CI
- add/update required runtime env vars listed in agent handoff
