### PR TITLE
Optimize web release image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -74,9 +71,11 @@ jobs:
         with:
           context: ./web
           file: ./web/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: |
             NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL=${{ vars.NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL }}
+          cache-from: type=gha,scope=feedback-web
+          cache-to: type=gha,mode=max,scope=feedback-web
           push: true
           tags: |
             nicolaidam/feedback-web:${{ env.VERSION }}

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.next
+.agents
+node_modules
+coverage
+playwright-report
+test-results
+tests
+AGENTS.md
+README.md
+*.log
+letsgrow_*.md

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,13 +1,16 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:20-alpine AS deps
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit
 
 FROM node:20-alpine AS build
 WORKDIR /app
 
 ARG NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL
+ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL=${NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL}
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -19,6 +22,7 @@ WORKDIR /app
 
 ARG NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL
 ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL=${NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL}
 


### PR DESCRIPTION
## Summary
- build the web release image for `linux/amd64` only instead of emulating `arm64` with QEMU
- enable GitHub Actions BuildKit cache reuse for the web Docker build
- add a `web/.dockerignore` and cache npm downloads during `npm ci`

## Why
The release workflow was spending most of its time in the frontend image build. The log showed the slow path was the emulated `linux/arm64` branch stalling in `npm ci`, while production compose already defaults to `linux/amd64` for runtime images.

## Validation
- `docker build --platform linux/amd64 -f web/Dockerfile web`

## Tradeoff
This stops publishing an `arm64` web image from the release workflow. If we need `arm64` later, we should add a native ARM build path rather than keep the QEMU-emulated install step.