### PR TITLE
Restore arm64 web release image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -71,7 +74,7 @@ jobs:
         with:
           context: ./web
           file: ./web/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL=${{ vars.NEXT_PUBLIC_LETSGROW_EARLY_ACCESS_URL }}
           cache-from: type=gha,scope=feedback-web


### PR DESCRIPTION
## Summary
- restore QEMU setup in the release workflow
- publish the web image for both linux/amd64 and linux/arm64 again
- keep the GitHub Actions cache settings added in #47

## Why
Coolify is deploying on an arm64 host. After #47, `nicolaidam/feedback-web:prod` was published for linux/amd64 only, which caused deployment to fail with `no matching manifest for linux/arm64 in the manifest list entries`.

## Validation
- checked the workflow diff in `.github/workflows/release.yml`
- confirmed `feedback-web:prod` only exposed an amd64 manifest while `feedback-api:prod` and `feedback-scheduler:prod` still exposed arm64 too
