### PR TITLE
[backend] Fix remaining backend Dependabot alerts

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -7,35 +7,9 @@ plugins {
 }
 
 val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
-val assertjVersion = versionCatalog.findVersion("assertj").get().requiredVersion
-val commonsCompressVersion = versionCatalog.findVersion("commonsCompress").get().requiredVersion
 val commonsLang3Version = versionCatalog.findVersion("commonsLang3").get().requiredVersion
-val grpcVersion = versionCatalog.findVersion("grpc").get().requiredVersion
 val jacksonVersion = versionCatalog.findVersion("jackson").get().requiredVersion
-val logbackVersion = versionCatalog.findVersion("logback").get().requiredVersion
-val forcedDependencies =
-    listOf(
-        "org.apache.commons:commons-compress:$commonsCompressVersion",
-    ) +
-        listOf(
-            "grpc-alts",
-            "grpc-api",
-            "grpc-auth",
-            "grpc-context",
-            "grpc-core",
-            "grpc-googleapis",
-            "grpc-grpclb",
-            "grpc-inprocess",
-            "grpc-netty-shaded",
-            "grpc-opentelemetry",
-            "grpc-protobuf",
-            "grpc-protobuf-lite",
-            "grpc-rls",
-            "grpc-services",
-            "grpc-stub",
-            "grpc-util",
-            "grpc-xds",
-        ).map { "io.grpc:$it:$grpcVersion" }
+val testcontainersVersion = versionCatalog.findVersion("testcontainers").get().requiredVersion
 
 repositories {
     mavenCentral()
@@ -55,18 +29,12 @@ subprojects {
         extensions.configure<DependencyManagementExtension>("dependencyManagement") {
             imports {
                 mavenBom("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
+                mavenBom("org.testcontainers:testcontainers-bom:$testcontainersVersion")
             }
 
             dependencies {
-                dependency("org.assertj:assertj-core:$assertjVersion")
                 dependency("org.apache.commons:commons-lang3:$commonsLang3Version")
-                dependency("ch.qos.logback:logback-classic:$logbackVersion")
-                dependency("ch.qos.logback:logback-core:$logbackVersion")
             }
         }
-    }
-
-    configurations.configureEach {
-        resolutionStrategy.force(*forcedDependencies.toTypedArray())
     }
 }

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -1,21 +1,17 @@
 [versions]
-assertj = "3.27.7"
-commonsCompress = "1.26.0"
 commonsLang3 = "3.18.0"
 exposed = "0.61.0"
-grpc = "1.75.0"
+firebase = "9.8.0"
 jackson = "2.21.1"
 junitPlatformLauncher = "1.12.2"
 kotlin = "2.3.0"
 liquibase = "5.0.1"
-logback = "1.5.25"
 postgres = "42.7.8"
-springboot = "3.5.9"
+springboot = "3.5.11"
 springDependencyPlugin = "1.1.7"
 springdoc = "2.8.14"
-testcontainers = "1.21.4"
+testcontainers = "2.0.3"
 openapi = "1.9.0"
-firebase = "9.7.0"
 ical4j = "4.2.2"
 h2 = "2.3.232"
 jib = "3.5.3"
@@ -54,7 +50,7 @@ springboot-mail = { module = "org.springframework.boot:spring-boot-starter-mail"
 #springboot-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
 #springboot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
 
-testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- upgrade direct backend dependencies where the patched versions are already available upstream: Spring Boot to 3.5.11, Firebase Admin to 9.8.0, and Testcontainers to 2.0.3
- align Jackson through the published Jackson BOM and keep a single explicit commons-lang3 override, which is still needed because Spring Boot 3.5.11 manages 3.17.0
- switch the Postgres Testcontainers module to its 2.x artifact name so the test suite resolves cleanly without a global force list

## Validation
- ./gradlew :api:dependencyInsight --configuration runtimeClasspath --dependency com.fasterxml.jackson.core:jackson-core
- ./gradlew :api:dependencyInsight --configuration runtimeClasspath --dependency ch.qos.logback:logback-core
- ./gradlew :api:dependencyInsight --configuration testRuntimeClasspath --dependency org.assertj:assertj-core
- ./gradlew :api:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.commons:commons-compress
- ./gradlew :scheduler:dependencyInsight --configuration runtimeClasspath --dependency io.grpc:grpc-netty-shaded
- ./gradlew :scheduler:dependencyInsight --configuration runtimeClasspath --dependency org.apache.commons:commons-lang3
- ./gradlew test

Closes #50