### PR TITLE
Remove email link sign-in

### DIFF
--- a/web/src/components/auth/LoginScreen.tsx
+++ b/web/src/components/auth/LoginScreen.tsx
@@ -2,21 +2,13 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useEffect, useState, type FormEvent } from "react"
-import { LoaderCircle, Mail, MoveRight } from "lucide-react"
+import { useEffect, useState } from "react"
+import { LoaderCircle, MoveRight } from "lucide-react"
 import AuthShell from "@/components/auth/AuthShell"
 import { useAuth } from "@/components/auth/AuthProvider"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import {
-  clearStoredEmailLinkAddress,
-  completeEmailLinkSignIn,
-  getStoredEmailLinkAddress,
-  isEmailLink,
-  sendEmailLink,
-  signInWithGoogle,
-} from "@/lib/auth"
+import { signInWithGoogle } from "@/lib/auth"
 
 function getErrorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) {
@@ -38,15 +30,8 @@ function LoginActionSpinner({ label }: Readonly<{ label: string }>) {
 export default function LoginScreen() {
   const router = useRouter()
   const { authError, configured, status } = useAuth()
-  const [email, setEmail] = useState("")
-  const [completionEmail, setCompletionEmail] = useState("")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [notice, setNotice] = useState<string | null>(null)
-  const [activeAction, setActiveAction] = useState<
-    "google" | "send-link" | "complete-link" | null
-  >(null)
-  const [needsLinkEmail, setNeedsLinkEmail] = useState(false)
-  const [linkMode, setLinkMode] = useState(false)
+  const [activeAction, setActiveAction] = useState<"google" | null>(null)
 
   useEffect(() => {
     if (status === "authenticated") {
@@ -54,44 +39,9 @@ export default function LoginScreen() {
     }
   }, [router, status])
 
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      setLinkMode(isEmailLink(window.location.href))
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!configured || !linkMode) {
-      return
-    }
-
-    const storedEmail = getStoredEmailLinkAddress()
-
-    if (!storedEmail) {
-      setNeedsLinkEmail(true)
-      return
-    }
-
-    setCompletionEmail(storedEmail)
-    setActiveAction("complete-link")
-    setErrorMessage(null)
-
-    completeEmailLinkSignIn(storedEmail, window.location.href)
-      .catch((error: unknown) => {
-        setErrorMessage(
-          getErrorMessage(error, "Unable to complete the email sign-in link.")
-        )
-        setNeedsLinkEmail(true)
-      })
-      .finally(() => {
-        setActiveAction(null)
-      })
-  }, [configured, linkMode])
-
   async function handleGoogleSignIn() {
     setActiveAction("google")
     setErrorMessage(null)
-    setNotice(null)
 
     try {
       await signInWithGoogle()
@@ -104,62 +54,13 @@ export default function LoginScreen() {
     }
   }
 
-  async function handleSendLink(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setActiveAction("send-link")
-    setErrorMessage(null)
-    setNotice(null)
-
-    try {
-      const normalizedEmail = await sendEmailLink(email)
-      setEmail(normalizedEmail)
-      setCompletionEmail(normalizedEmail)
-      setNeedsLinkEmail(false)
-      setNotice(`Magic link sent to ${normalizedEmail}. Open it in this browser.`)
-    } catch (error: unknown) {
-      setErrorMessage(
-        getErrorMessage(error, "Unable to send the email sign-in link.")
-      )
-    } finally {
-      setActiveAction(null)
-    }
-  }
-
-  async function handleCompleteLink(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setActiveAction("complete-link")
-    setErrorMessage(null)
-    setNotice(null)
-
-    try {
-      await completeEmailLinkSignIn(completionEmail, window.location.href)
-      setNeedsLinkEmail(false)
-    } catch (error: unknown) {
-      setErrorMessage(
-        getErrorMessage(error, "Unable to complete the email sign-in link.")
-      )
-    } finally {
-      setActiveAction(null)
-    }
-  }
-
-  function handleResetLinkState() {
-    clearStoredEmailLinkAddress()
-    setNeedsLinkEmail(true)
-    setCompletionEmail("")
-    setNotice(null)
-    setErrorMessage(null)
-  }
-
   const isBusy = activeAction !== null || status === "loading"
   const busyLabel =
     status === "loading"
       ? "Checking your session..."
       : activeAction === "google"
         ? "Opening Google sign-in..."
-        : activeAction === "send-link"
-          ? "Sending your sign-in link..."
-          : null
+        : null
   const configMessage = !configured
     ? authError ??
       "Firebase is not configured yet. Add the required NEXT_PUBLIC_FIREBASE_* variables to enable sign-in."
@@ -169,7 +70,7 @@ export default function LoginScreen() {
   return (
     <AuthShell
       badge="Lets Grow access"
-      description="Use Google or a secure email link to open your feedback dashboard without changing the existing landing page."
+      description="Use Google to open your feedback dashboard without changing the existing landing page."
       title="Sign in to your meeting feedback dashboard"
     >
       <Card className="border-white/80 bg-white/85 shadow-2xl shadow-slate-900/10 backdrop-blur">
@@ -192,16 +93,6 @@ export default function LoginScreen() {
             <LoginActionSpinner label={busyLabel} />
           ) : null}
 
-          {configured && activeAction === "complete-link" ? (
-            <LoginActionSpinner label="Completing your email sign-in..." />
-          ) : null}
-
-          {notice ? (
-            <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
-              {notice}
-            </div>
-          ) : null}
-
           {displayError ? (
             <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-950">
               {displayError}
@@ -217,86 +108,7 @@ export default function LoginScreen() {
             >
               Continue with Google
             </Button>
-
-            <div className="flex items-center gap-3 text-xs uppercase tracking-[0.25em] text-slate-400">
-              <span className="h-px flex-1 bg-slate-200" />
-              <span>Email link</span>
-              <span className="h-px flex-1 bg-slate-200" />
-            </div>
-
-            <form className="space-y-3" onSubmit={handleSendLink}>
-              <label className="block space-y-2 text-sm font-medium text-slate-700">
-                <span>Email address</span>
-                <div className="relative">
-                  <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                  <Input
-                    autoComplete="email"
-                    className="pl-10"
-                    disabled={!configured || isBusy}
-                    onChange={(event) => setEmail(event.target.value)}
-                    placeholder="name@company.com"
-                    required
-                    type="email"
-                    value={email}
-                  />
-                </div>
-              </label>
-
-              <Button
-                className="h-11 w-full rounded-xl"
-                disabled={!configured || isBusy}
-                type="submit"
-              >
-                Send sign-in link
-              </Button>
-            </form>
           </div>
-
-          {configured && needsLinkEmail ? (
-            <form
-              className="space-y-3 rounded-2xl border border-sky-100 bg-sky-50/70 p-4"
-              onSubmit={handleCompleteLink}
-            >
-              <div className="space-y-1">
-                <h3 className="text-sm font-semibold text-sky-950">
-                  Finish your email sign-in
-                </h3>
-                <p className="text-sm leading-6 text-sky-900/80">
-                  Opened the magic link on a different device or browser? Enter
-                  the email address that received it to finish the sign-in.
-                </p>
-              </div>
-
-              <Input
-                autoComplete="email"
-                disabled={isBusy}
-                onChange={(event) => setCompletionEmail(event.target.value)}
-                placeholder="name@company.com"
-                required
-                type="email"
-                value={completionEmail}
-              />
-
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <Button
-                  className="flex-1 rounded-xl"
-                  disabled={isBusy}
-                  type="submit"
-                >
-                  Complete sign-in
-                </Button>
-                <Button
-                  className="flex-1 rounded-xl"
-                  disabled={isBusy}
-                  onClick={handleResetLinkState}
-                  type="button"
-                  variant="outline"
-                >
-                  Reset link state
-                </Button>
-              </div>
-            </form>
-          ) : null}
 
           <p className="flex items-center justify-between gap-2 text-xs text-slate-500">
             <span>Signed-in users are routed directly to the dashboard.</span>

--- a/web/src/lib/auth/e2e-auth-client.ts
+++ b/web/src/lib/auth/e2e-auth-client.ts
@@ -1,12 +1,6 @@
 "use client"
 
-import {
-  clearStoredEmailLinkAddress,
-  emailStorageKey,
-  getStoredEmailLinkAddress,
-  normalizeEmail,
-  createProviderData,
-} from "@/lib/auth/shared"
+import { createProviderData } from "@/lib/auth/shared"
 import type {
   AppAuthUser,
   AuthClient,
@@ -19,33 +13,8 @@ const e2eUserStorageKey = "feedback.e2e.auth.user"
 export class E2EAuthClient implements AuthClient {
   private readonly listeners = new Set<(user: AppAuthUser | null) => void>()
 
-  clearStoredEmailLinkAddress() {
-    clearStoredEmailLinkAddress()
-  }
-
-  async completeEmailLinkSignIn(email: string, _url: string) {
-    void _url
-    const normalizedEmail = normalizeEmail(email)
-
-    this.setUser({
-      displayName: normalizedEmail,
-      email: normalizedEmail,
-      providerData: createProviderData(
-        "emailLink",
-        normalizedEmail,
-        normalizedEmail
-      ),
-      uid: `playwright-email-${normalizedEmail}`,
-    })
-    clearStoredEmailLinkAddress()
-  }
-
   getConfigError() {
     return null
-  }
-
-  getStoredEmailLinkAddress() {
-    return getStoredEmailLinkAddress()
   }
 
   initializePersistence() {
@@ -54,21 +23,6 @@ export class E2EAuthClient implements AuthClient {
 
   isConfigured() {
     return true
-  }
-
-  isEmailLink(url: string) {
-    const currentUrl = new URL(url)
-    return currentUrl.searchParams.get("mode") === "signIn"
-  }
-
-  async sendEmailLink(email: string) {
-    const normalizedEmail = normalizeEmail(email)
-
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(emailStorageKey, normalizedEmail)
-    }
-
-    return normalizedEmail
   }
 
   async signInWithGoogle() {

--- a/web/src/lib/auth/firebase-auth-client.ts
+++ b/web/src/lib/auth/firebase-auth-client.ts
@@ -10,20 +10,11 @@ import {
   GoogleAuthProvider,
   browserLocalPersistence,
   getAuth,
-  isSignInWithEmailLink as firebaseIsSignInWithEmailLink,
   onAuthStateChanged,
-  sendSignInLinkToEmail,
   setPersistence,
-  signInWithEmailLink,
   signInWithPopup,
   signOut,
 } from "firebase/auth"
-import {
-  clearStoredEmailLinkAddress,
-  emailStorageKey,
-  getStoredEmailLinkAddress,
-  normalizeEmail,
-} from "@/lib/auth/shared"
 import {
   requiredFirebaseConfigKeys,
   type FirebaseConfigInput,
@@ -56,31 +47,12 @@ export class FirebaseAuthClient implements AuthClient {
     this.googleProvider.setCustomParameters({ prompt: "select_account" })
   }
 
-  clearStoredEmailLinkAddress() {
-    clearStoredEmailLinkAddress()
-  }
-
-  async completeEmailLinkSignIn(email: string, url: string) {
-    const normalizedEmail = normalizeEmail(email)
-
-    await signInWithEmailLink(
-      this.requireFirebaseAuth(),
-      normalizedEmail,
-      url
-    )
-    clearStoredEmailLinkAddress()
-  }
-
   getConfigError() {
     if (this.firebaseConfig) {
       return null
     }
 
     return `Missing Firebase configuration: ${this.missingConfigKeys.join(", ")}`
-  }
-
-  getStoredEmailLinkAddress() {
-    return getStoredEmailLinkAddress()
   }
 
   initializePersistence() {
@@ -93,22 +65,6 @@ export class FirebaseAuthClient implements AuthClient {
 
   isConfigured() {
     return this.firebaseConfig !== null
-  }
-
-  isEmailLink(url: string) {
-    const auth = this.getFirebaseAuth()
-    return auth ? firebaseIsSignInWithEmailLink(auth, url) : false
-  }
-
-  async sendEmailLink(email: string) {
-    const normalizedEmail = normalizeEmail(email)
-
-    await sendSignInLinkToEmail(this.requireFirebaseAuth(), normalizedEmail, {
-      url: `${window.location.origin}/login`,
-      handleCodeInApp: true,
-    })
-    window.localStorage.setItem(emailStorageKey, normalizedEmail)
-    return normalizedEmail
   }
 
   async signInWithGoogle() {

--- a/web/src/lib/auth/index.ts
+++ b/web/src/lib/auth/index.ts
@@ -81,26 +81,6 @@ export function signInWithGoogle() {
   return authClient.signInWithGoogle()
 }
 
-export function sendEmailLink(email: string) {
-  return authClient.sendEmailLink(email)
-}
-
-export function isEmailLink(url: string) {
-  return authClient.isEmailLink(url)
-}
-
-export function getStoredEmailLinkAddress() {
-  return authClient.getStoredEmailLinkAddress()
-}
-
-export function clearStoredEmailLinkAddress() {
-  authClient.clearStoredEmailLinkAddress()
-}
-
-export function completeEmailLinkSignIn(email: string, url: string) {
-  return authClient.completeEmailLinkSignIn(email, url)
-}
-
 export function signOut() {
   return authClient.signOut()
 }

--- a/web/src/lib/auth/shared.ts
+++ b/web/src/lib/auth/shared.ts
@@ -1,25 +1,5 @@
 import type { UserInfo } from "firebase/auth"
 
-export const emailStorageKey = "feedback.auth.email-link"
-
-export function normalizeEmail(email: string) {
-  return email.trim().toLowerCase()
-}
-
-export function getStoredEmailLinkAddress() {
-  if (typeof window === "undefined") {
-    return null
-  }
-
-  return window.localStorage.getItem(emailStorageKey)
-}
-
-export function clearStoredEmailLinkAddress() {
-  if (typeof window !== "undefined") {
-    window.localStorage.removeItem(emailStorageKey)
-  }
-}
-
 export function createProviderData(
   providerId: string,
   email: string | null,

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -12,14 +12,9 @@ export type AuthStateListener = (user: AppAuthUser | null) => void
 export type AuthErrorListener = (error: unknown) => void
 
 export interface AuthClient {
-  clearStoredEmailLinkAddress(): void
-  completeEmailLinkSignIn(email: string, url: string): Promise<void>
   getConfigError(): string | null
-  getStoredEmailLinkAddress(): string | null
   initializePersistence(): Promise<void>
   isConfigured(): boolean
-  isEmailLink(url: string): boolean
-  sendEmailLink(email: string): Promise<string>
   signInWithGoogle(): Promise<void>
   signOut(): Promise<void>
   subscribeToAuthState(


### PR DESCRIPTION
## Summary
- remove the email-link sign-in UI from the login screen
- delete the email-link methods and local-storage helpers from the auth layer
- keep Google as the only supported sign-in path for the MVP

## Verification
- npm run lint
- npm run build