### PR TITLE
Remove redundant Liquibase compose env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
     environment:
       PORT: "8080"
       MANAGEMENT_SERVER_PORT: "8091"
-      SPRING_LIQUIBASE_ENABLED: "true"
       POSTGRES_HOST:
       POSTGRES_PORT:
       POSTGRES_DB:


### PR DESCRIPTION
Summary:
- remove the redundant SPRING_LIQUIBASE_ENABLED environment variable from the scheduler service in docker-compose.yml
- keep Compose runtime behavior unchanged because both API and scheduler already enable Liquibase in application config

Validation:
- ./gradlew clean build in backend on this branch: fails in pre-existing :api:test E2E tests
- ./gradlew clean build in backend on main: same three E2ETest failures reproduced
- npm ci
- npm run lint
- npm run build
- docker compose config with placeholder required env vars