### PR TITLE
Remove amd64 platform pins from production compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ name: feedback
 services:
   api:
     image: "nicolaidam/feedback-api:prod"
-    platform: "linux/amd64"
     restart: unless-stopped
     environment:
       PORT: "8080"
@@ -27,7 +26,6 @@ services:
 
   scheduler:
     image: "nicolaidam/feedback-scheduler:prod"
-    platform: "linux/amd64"
     restart: unless-stopped
     environment:
       PORT: "8080"
@@ -53,7 +51,6 @@ services:
 
   web:
     image: "nicolaidam/feedback-web:prod"
-    platform: "linux/amd64"
     restart: unless-stopped
     environment:
       NODE_ENV: production


### PR DESCRIPTION
## Summary
- remove the hard-coded  platform pins from the production Compose services
- let Coolify pull the correct image variant for the host architecture instead of forcing x86_64
- preserve the existing multi-arch image publishing setup for web and backend

## Problem
Coolify deployments were failing with repeated  messages. The production Compose file forced , , and  to run as , which breaks on ARM64 hosts.

## Validation
- rendered  successfully with placeholder env values after removing the platform pins
- confirmed the release pipeline and backend Jib config are intended to publish  and  variants
